### PR TITLE
composer.json: bump sweetrdf/rdf-helpers to ^2.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": ">=8.0",
         "sweetrdf/rdf-interface": "^2.0.0-RC1",
-        "sweetrdf/rdf-helpers": "^1.0.2"
+        "sweetrdf/rdf-helpers": "^2.0.0"
     },
     "suggest": {
         "sweetrdf/quick-rdf": "^2.0.0-RC1",


### PR DESCRIPTION
It seems to work out of the box, so maybe rdf-helpers 1.x and 2.x can be supported. What do you think?

I wanted to use it with latest EasyRdf release (1.14.0), but composer complaints because it requires rdf-helps v2.0+